### PR TITLE
Fix docstring for cacheName of CacheRemoveAll annotation

### DIFF
--- a/src/main/java/javax/cache/annotation/CacheRemoveAll.java
+++ b/src/main/java/javax/cache/annotation/CacheRemoveAll.java
@@ -73,7 +73,6 @@ import java.lang.annotation.Target;
 public @interface CacheRemoveAll {
 
   /**
-   * /**
    * The name of the cache.
    * <p>
    * If not specified defaults first to {@link CacheDefaults#cacheName()} and if


### PR DESCRIPTION
Remove a duplicated opening docstring comment for the `cacheName` property of the `CacheRemoveAll` annotation.